### PR TITLE
Adding codeowners-rs dotslash exe

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fast_code_owners (0.0.2)
+    fast_code_owners (0.0.3)
       code_teams (~> 1.0)
       packs-specification
       sorbet-runtime

--- a/exe/codeowners-rs
+++ b/exe/codeowners-rs
@@ -1,0 +1,79 @@
+#!/usr/bin/env dotslash
+
+{
+  "name": "codeowners",
+  "platforms": {
+    "macos-x86_64": {
+      "size": 3654984,
+      "hash": "blake3",
+      "digest": "fbc22ee43800b02663b25decad60a94daddb399fa5c81348c9af5e674d5d961e",
+      "format": "tar.gz",
+      "path": "codeowners",
+      "providers": [
+        {
+          "url": "https://github.com/perryqh/codeowners-rs-workflow/releases/download/v0.1.5/codeowners-mac.tar.gz"
+        },
+        {
+          "type": "github-release",
+          "repo": "https://github.com/perryqh/codeowners-rs-workflow",
+          "tag": "v0.1.5",
+          "name": "codeowners-mac.tar.gz"
+        }
+      ]
+    },
+    "macos-aarch64": {
+      "size": 3654984,
+      "hash": "blake3",
+      "digest": "fbc22ee43800b02663b25decad60a94daddb399fa5c81348c9af5e674d5d961e",
+      "format": "tar.gz",
+      "path": "codeowners",
+      "providers": [
+        {
+          "url": "https://github.com/perryqh/codeowners-rs-workflow/releases/download/v0.1.5/codeowners-mac.tar.gz"
+        },
+        {
+          "type": "github-release",
+          "repo": "https://github.com/perryqh/codeowners-rs-workflow",
+          "tag": "v0.1.5",
+          "name": "codeowners-mac.tar.gz"
+        }
+      ]
+    },
+    "linux-x86_64": {
+      "size": 16395080,
+      "hash": "blake3",
+      "digest": "031c7bcf500cee68dc9e1385439abf4986a7b45fec6da6f23f9221c483484ad8",
+      "format": "tar.gz",
+      "path": "codeowners",
+      "providers": [
+        {
+          "url": "https://github.com/perryqh/codeowners-rs-workflow/releases/download/v0.1.5/x86_64-unknown-linux-gnu.tar.gz"
+        },
+        {
+          "type": "github-release",
+          "repo": "https://github.com/perryqh/codeowners-rs-workflow",
+          "tag": "v0.1.5",
+          "name": "x86_64-unknown-linux-gnu.tar.gz"
+        }
+      ]
+    },
+    "linux-aarch64": {
+      "size": 15518470,
+      "hash": "blake3",
+      "digest": "938d332626d6a84ed9fd5c971aa2ed56a638735ec65e35a92ee454a41d3dc6a9",
+      "format": "tar.gz",
+      "path": "codeowners",
+      "providers": [
+        {
+          "url": "https://github.com/perryqh/codeowners-rs-workflow/releases/download/v0.1.5/aarch64-unknown-linux-gnu.tar.gz"
+        },
+        {
+          "type": "github-release",
+          "repo": "https://github.com/perryqh/codeowners-rs-workflow",
+          "tag": "v0.1.5",
+          "name": "aarch64-unknown-linux-gnu.tar.gz"
+        }
+      ]
+    }
+  }
+}

--- a/fast_code_owners.gemspec
+++ b/fast_code_owners.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
     end
   end
   spec.bindir = 'exe'
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.executables = ['codeowners-rs']
   spec.require_paths = ['lib']
   spec.extensions = ['ext/fast_code_owners/Cargo.toml']
 

--- a/lib/fast_code_owners/version.rb
+++ b/lib/fast_code_owners/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FastCodeOwners
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
Adding the rubyatscale/codeowners-rs dotslash generated file to `./exe`. This PR is just testing if it works as expected.

If all goes well, the rake task can pull down the dotslash file matching the version of codeowner-rs specified in the toml file.

I'm not make a standard `bin/fast_code_owners` binstub that would kick off the ruby code in this gem, but rather directly adding the codeowner-rs binary via dotslash. This offer a significant performance boost.